### PR TITLE
fixed sintax error on compos

### DIFF
--- a/varios/1/docker-compose.yaml
+++ b/varios/1/docker-compose.yaml
@@ -25,8 +25,6 @@ services:
       - vhostd:/etc/nginx/vhost.d
       - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    volumes_from:
-      - nginx-proxy:rw
 
   www:
     image: nginx


### PR DESCRIPTION
invalid syntax on docker-compose.
volumes_from is not valid sintax in compose v3.
I only remove this line, the volumes are already setted.