### PR TITLE
Actualización de 01-hello-app-deployment.yaml por cambio de versión

### DIFF
--- a/kubernetes/3/01-hello-app-deployment.yaml
+++ b/kubernetes/3/01-hello-app-deployment.yaml
@@ -1,17 +1,22 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hello
+  name: helloweb
+  labels:
+    app: hello
 spec:
-  replicas: 3
+  selector:
+    matchLabels:
+      app: hello
+      tier: web
   template:
     metadata:
       labels:
-        role: hello
+        app: hello
+        tier: web
     spec:
       containers:
-      - name: hello
+      - name: hello-app
         image: gcr.io/google-samples/hello-app:1.0
-        imagePullPolicy: IfNotPresent        
         ports:
         - containerPort: 8080

--- a/kubernetes/3/01-hello-app-deployment.yaml
+++ b/kubernetes/3/01-hello-app-deployment.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: helloweb
+  name: hello
   labels:
-    app: hello
+    role: hello
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: hello
+      role: hello
       tier: web
   template:
     metadata:
       labels:
-        app: hello
+        role: hello
         tier: web
     spec:
       containers:

--- a/kubernetes/3/01-hello-app-deployment.yaml
+++ b/kubernetes/3/01-hello-app-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: hello
 spec:
+  replicas: 3
   selector:
     matchLabels:
       app: hello

--- a/kubernetes/3/03-hello-app-deployment.yaml
+++ b/kubernetes/3/03-hello-app-deployment.yaml
@@ -1,13 +1,20 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello
+  labels:
+    role: hello
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      role: hello
+      tier: web
   template:
     metadata:
       labels:
         role: hello
+        tier: web
     spec:
       containers:
       - name: hello


### PR DESCRIPTION
 Se reemplaza el contenido del deployment kubernetes/3/01-hello-app-deployment.yaml por el yaml ubicado en la URL:
    https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/master/hello-app/manifests/helloweb-deployment.yaml
    
    Se producía el error:
    
    - error: unable to recognize "01-hello-app-deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
    
    luego de modificar:
    
    apiVersion: extensions/v1beta1
    
    por:
    
    apiVersion: apps/v1
    
    se produjo el error:
    
    - kubectl apply -f 01-hello-app-deployment.yaml
    error: unable to recognize "01-hello-app-deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
