### PR TITLE
fixed ttl , added mx record

### DIFF
--- a/terraform/3/03_dns.tf
+++ b/terraform/3/03_dns.tf
@@ -9,7 +9,16 @@ resource "digitalocean_record" "mail" {
   domain = "${digitalocean_domain.pablokbs.name}"
   type   = "A"
   name   = "mail"
-  ttl    = "10"
+  ttl    = "30"
   value  = "${digitalocean_droplet.mail.ipv4_address}"
 }
 
+# Add mx record to the domain (so it can receive emails)
+resource "digitalocean_record" "mx" {
+  domain = "${digitalocean_domain.pablokbs.name}"
+  type   = "MX"
+  name   = "@"
+  priority    = "10"
+  ttl    = "14400"
+  value  = "mail.${digitalocean_domain.pablokbs.name}."
+}


### PR DESCRIPTION
Arregla error :

Error: Failed to update record: PUT https://api.digitalocean.com: 422 record ttl must be greater than 30

Y agrega creación del MX record al archivo tf de DNS 