### PR TITLE
se agrega selector para deployment de prometheus

### DIFF
--- a/kubernetes/7/03-prometheus-deployment.yaml
+++ b/kubernetes/7/03-prometheus-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-server
   template:
     metadata:
       labels:


### PR DESCRIPTION
Para que pase la validación al aplicar el yaml del deployment. El selector es obligatorio para la apiVersion: apps/v1