### PR TITLE
Rclone for Samba

### DIFF
--- a/v2m/26/dkgit
+++ b/v2m/26/dkgit
@@ -1,0 +1,41 @@
+version: '3'
+
+services:
+  samba:
+    image: dperson/samba:rpi
+    restart: always
+    command: '-u "backup;root" -s "media;/media;yes;no"'
+    stdin_open: true
+    tty: true
+    ports:
+      - '139:130'
+      - '445:445'
+    volumes:
+      - '/usr/share/zoneinfo/America/El_Salvador:/etc/localtime'
+      - '/mnt/gdrive:/media'
+    depends_on:
+      - rclone-mount
+ 
+  rclone-mount:
+    image: pablokbs/rclone-mount:armhf
+    restart: unless-stopped
+    ports:
+      - '80:80'
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - 'apparmor:unconfined'
+    volumes:
+      - '/var/run/docker.sock:/tmp/docker.sock:ro'
+      - '/root/.config/rclone:/config'
+      - '/mnt/gdrive:/mnt/mediaefs:shared'
+    logging:
+      options:
+        max-size: 1g
+    container_name: rclone-mount
+    devices:
+      - /dev/fuse
+    environment:
+      - 'RemotePath=gdrive:'
+      - 'MountCommands=--allow-other --allow-non-empty --buffer-size 256M'
+      - 'ConfigName=rclone.conf'


### PR DESCRIPTION
Esta Rama contiene un archivo llamdo dkgit este archivo es el docker compose que contiene Samba Dependiente de
Rclone.
SI quieres Ocuparlo Solo debes de descargar el archivo dkgit en la carpeta /v2m/26/dkgit y renombrarlo como docker-compose.yaml despues corres docker-compose up -d en la misma carpeta (lo mismo que el video del pelado solo que renombras este segundo archivo) y tienes tu Carpeta compartida en Samba Con Rclone
