### PR TITLE
Agregando selector a deployment en 9/daemonsets issue #108

### DIFF
--- a/kubernetes/9/02-hello-app-deployment.yaml
+++ b/kubernetes/9/02-hello-app-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: hello
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      role: hello
   template:
     metadata:
       labels:


### PR DESCRIPTION
Se agrega selector ya que al aplicar manifiesto  kubernetes/9/02-hello-app-deployment.yaml no encuentra selector:

# kubectl apply -f 02-hello-app-deployment.yaml
error: error validating "02-hello-app-deployment.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
