### PR TITLE
Include selectors 9 k8s

### DIFF
--- a/kubernetes/9/02-hello-app-deployment.yaml
+++ b/kubernetes/9/02-hello-app-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: hello
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      role: hello
   template:
     metadata:
       labels:

--- a/kubernetes/9/03-fluentd-daemonset.yaml
+++ b/kubernetes/9/03-fluentd-daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
     kubernetes.io/cluster-service: "true"
     version: v1.20
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-es
   template:
     metadata:
       labels:


### PR DESCRIPTION
error: error validating "03-fluentd-daemonset.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false

Se agrega selector a manifiesto fluentd kubernetes/9/03-fluentd-daemonset.yaml