### PR TITLE
Added provider source needed by terraform 0.14.6

### DIFF
--- a/terraform/1/_provider.tf
+++ b/terraform/1/_provider.tf
@@ -1,5 +1,15 @@
 variable "digitalocean_token" {}
 
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+    }
+  }
+}
+
 # Configure the DigitalOcean Provider
 provider "digitalocean" {
   token = "${var.digitalocean_token}"


### PR DESCRIPTION
Con la versión 0.14.6, al lanzar ```terraform init``` se produce este error:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
hashicorp/digitalocean: provider registry registry.terraform.io does not have
a provider named registry.terraform.io/hashicorp/digitalocean

If you have just upgraded directly from Terraform v0.12 to Terraform v0.14
then please upgrade to Terraform v0.13 first and follow the upgrade guide for
that release, which might help you address this problem.

Did you intend to use digitalocean/digitalocean? If so, you must specify that
source address in each module which requires that provider. To see which
modules are currently depending on hashicorp/digitalocean, run the following
command:
    terraform providers
```

Creo que a partir de la versión 0.13 es necesario especificar la fuente de los providers.