### PR TITLE
Interpolation syntax is deprecated after terraform 0.11

### DIFF
--- a/terraform/1/_provider.tf
+++ b/terraform/1/_provider.tf
@@ -2,6 +2,6 @@ variable "digitalocean_token" {}
 
 # Configure the DigitalOcean Provider
 provider "digitalocean" {
-  token = "${var.digitalocean_token}"
+  token = var.digitalocean_token
 }
 


### PR DESCRIPTION
Al lanzar ```terraform init```con terraform 0.14.6 se produce el siguiente Waening:

```
Warning: Interpolation-only expressions are deprecated

  on 01_ssh_key.tf line 6, in resource "digitalocean_ssh_key" "pelado":
   6:   public_key = "${file("id_rsa.pub")}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

terraform {
Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and 5 more similar warnings elsewhere)
```