### PR TITLE
Security Update

### DIFF
--- a/varios/12/docker-compose.yaml
+++ b/varios/12/docker-compose.yaml
@@ -33,12 +33,11 @@ services:
   pihole:
     container_name: pihole
     image: pihole/pihole:v5.7
-    ports:
-      - "53:53/tcp"
-      - "53:53/udp"
-      - "67:67/udp"
-      - "80:80/tcp"
-      - "443:443/tcp"
+    expose:
+      - "53"
+      - "67"
+      - "80"
+      - "443"
     environment:
       TZ: 'America/Mendoza'
       WEBPASSWORD: 'peladonerd'


### PR DESCRIPTION
Al poner "ports" docker configura iptables y permite al mundo a acceder a estos puertos. Lo he cambiado a "expose" para que solo los que estan dentro de la VPN de wireguard puedan entrar. Normalmente no es un problema en LightSail o DigitalOcean, pero UPCLOUD tiene por defecto desactivado el firewall (y te cobran por activarlo).