### PR TITLE
Letsencrypt "duch" lanza error

### DIFF
--- a/raspi/7/docker-compose.yaml
+++ b/raspi/7/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
 
   letsencrypt:
-    image: duch/letsencrypt-nginx-proxy-companion:stable
+    image: jrcs/letsencrypt-nginx-proxy-companion:stable
     restart: always
     volumes:
       - certs:/etc/nginx/certs:rw


### PR DESCRIPTION
Como comento @txixo0 en esta issue ( https://github.com/pablokbs/peladonerd/issues/126#issuecomment-763601998 ) la imagen "duch/letsencrypt-nginx-proxy-companion" lanza un error al iniciar y no es capaz de crear los certificados.
Como no supo/pudo crear un PR y creo que es importante lo he creado yo. Un saludo y gracias por vuestro trabajo.