### PR TITLE
Remove deprecated versions warning.

### DIFF
--- a/kubernetes/5/metrics/auth-delegator.yaml
+++ b/kubernetes/5/metrics/auth-delegator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator

--- a/kubernetes/5/metrics/auth-reader.yaml
+++ b/kubernetes/5/metrics/auth-reader.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-server-auth-reader

--- a/kubernetes/5/metrics/metrics-apiservice.yaml
+++ b/kubernetes/5/metrics/metrics-apiservice.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io


### PR DESCRIPTION
Bump to lastest version

Remove warnings :
rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+;
rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+;
apiregistration.k8s.io/v1beta1 APIService is deprecated in v1.19+, unavailable in v1.22+;
