### PR TITLE
 Update de los comandos para instalar LATEST

### DIFF
--- a/v2m/27/comandos.txt
+++ b/v2m/27/comandos.txt
@@ -1,9 +1,10 @@
-# Levanta con volumen en el host
+# Levanta con volumen en el host (Para Portainer Version 2.5(latest))
 
 docker volume create portainer_data
 
-docker run -d -p 9000:9000 --name=portainer --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v portainer_data:/data portainer/portainer
+docker run -d -p 8000:8000 -p 9000:9000 --name=portainer --restart=always -v /var/run/docker.sock:/var/run/docker.sock -v portainer_data:/data portainer/portainer-ce
 
 # Levanta sin volumen en el host
 
-docker run -d -p 9000:9000 --name=portainer --restart=always -v /var/run/docker.sock:/var/run/docker.sock portainer/portainer
+docker run -d -p 8000:8000 -p 9000:9000 --name=portainer --restart=always -v /var/run/docker.sock:/var/run/docker.sock portainer/portainer-ce
+

--- a/v2m/27/docker-compose.yaml
+++ b/v2m/27/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: "3.8"
+
+services:
+
+  portainer:
+    container_name: portainer
+    image: portainer/portainer-ce:latest
+    restart: always
+    ports:
+      - 9000:9000
+      - 8000:8000
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - './portainer_data:/data'
+    hostname: portainer
+
+# Instalando el Portainer Agent se puede conectar hacia este nodo y monitorearlo desde otro Portainer remoto
+# agregandoló como un "Endpoint" del tipo "Agent", apuntando a la IP:9001 del nodo local
+portainer-agent:
+    container_name: portainer-agent
+    image: portainer/agent
+    ports:
+      - 9001:9001
+    restart: always
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - '/var/lib/docker/volumes:/var/lib/docker/volumes'
+    hostname: portainer-agent


### PR DESCRIPTION
Portainer deprecó el repo de dockerhub con el nombre "portainer/portainer" en la version 1.24.2, y ahora cambió el nombre de los repos a portainer/portainer-ce .