### PR TITLE
Updated proxy.conf for Registry location

### DIFF
--- a/docker/10/proxy.conf
+++ b/docker/10/proxy.conf
@@ -62,7 +62,8 @@ server {
         proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        #proxy_set_header X-Forwarded-Proto $scheme; 
+        proxy_set_header X-Forwarded-Proto https;
         proxy_read_timeout                 900;
         proxy_pass https://registry;
     }


### PR DESCRIPTION
Para la locación de Registry comento la linea "proxy_set_header X-Forwarded-Proto $scheme" y agrego "proxy_set_header X-Forwarded-Proto https" debido que al intentar hacer push al registro arrojaba error "unknown blob".
La solución la saque de aquí. https://github.com/distribution/distribution/issues/2225#issuecomment-356882178