### PR TITLE
Varios/1 actualiza las versiones de las imágenes y agrega los volúmenes necesarios

### DIFF
--- a/varios/1/docker-compose.yaml
+++ b/varios/1/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: nginxproxy/nginx-proxy:0.9
     restart: always
     ports:
       - "80:80"
@@ -11,23 +11,25 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - certs:/etc/nginx/certs:ro
       - vhostd:/etc/nginx/vhost.d
+      - dhparam:/etc/nginx/dhparam
       - html:/usr/share/nginx/html
     labels:
       - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
 
   letsencrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: nginxproxy/acme-companion:2.0.2
     restart: always
     environment:
       - NGINX_PROXY_CONTAINER=nginx-proxy
     volumes:
       - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
       - vhostd:/etc/nginx/vhost.d
       - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   www:
-    image: nginx
+    image: nginx:1.21.1
     restart: always
     expose:
       - "80"
@@ -44,3 +46,5 @@ volumes:
   certs:
   html:
   vhostd:
+  dhparam:
+  acme:


### PR DESCRIPTION
A partir de la v2 de acme-companion se requiere generar un nuevo volumen ```- acme: /etc/acme.sh ```  para permitir guardar las keys de la cuenta ACME y los certificados SSL.

En este PR se agrega este volumen y además se actualiza el  docker-compose.yml para utilizar las mismas imágenes que utilizan en la [documentación](https://github.com/nginx-proxy/acme-companion/blob/main/docs/Docker-Compose.md)

Closes pablokbs/peladonerd#178