### PR TITLE
fix(_provider.tf): Failed to query available provider packages

### DIFF
--- a/terraform/2/_provider.tf
+++ b/terraform/2/_provider.tf
@@ -1,5 +1,13 @@
 variable "digitalocean_token" {}
 
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+    }
+  }
+}
+
 # Configure the DigitalOcean Provider
 provider "digitalocean" {
   token = "${var.digitalocean_token}"


### PR DESCRIPTION
### Error al crear el _provider.tf para DO:
Estuve viendo y practicando el tutorial de DO con Terraform cuando me encontré con un error en el _provider.tf a la hora de generar la infraestructura. 

### Que ha cambiado:
1. Cambio en el código de _provider.tf.
2. Se agregó el bloque de código donde se declara el provider a utilizar.

### Lo que el revisor debe saber:
El ejemplo actual  de _provider.tf da problemas a la hora de hacer `terraform init` para inicializar la infraestructura en la V0.14 de Terraform. Al investigar el problema pude ver que la misma no genera automáticamente el bloque de configuración de proveedor, por lo que pude investigar y aprender si se utiliza la v0.13 se auto genera a la hora de hacer `terraform init`, pero en la v0.14 debemos insertar el el bloque de código y especificar el proveedor que queremos utilizar. Hoy en día la documentación de DO con terraform recomienda insertar el bloque de configuración.
Adjunto la documentación vista y el error generado: 
Documentación: https://www.digitalocean.com/community/tutorials/how-to-use-terraform-with-digitalocean 
Error:
```
Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/digitalocean: provider
│ registry registry.terraform.io does not have a provider named
│ registry.terraform.io/hashicorp/digitalocean
│ 
│ Did you intend to use digitalocean/digitalocean? If so, you must specify that source address in
│ each module which requires that provider. To see which modules are currently depending on
│ hashicorp/digitalocean, run the following command:
│     terraform providers`
```
