### PR TITLE
Se cambia networking.k8s.io/v1beta1 por networking.k8s.io/v1

### DIFF
--- a/kubernetes/8/05-ingress.yaml
+++ b/kubernetes/8/05-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress
@@ -6,15 +6,24 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - host: v1.peladonerd.local 
+  - host: v1.peladonerd.local
     http:
       paths:
-      - backend:
-          serviceName: hello-v1-svc
-          servicePort: 80
-  - host: v2.peladonerd.local
+      - path: /
+        pathType: Exact
+        backend:
+          service:
+            name: hello-v1-svc
+            port:
+              number: 80
+        
+  - host: v2.peladonerd.local 
     http:
       paths:
-      - backend:
-          serviceName: hello-v2-svc
-          servicePort: 80
+      - path: /
+        pathType: Exact
+        backend:
+          service:
+            name: hello-v2-svc
+            port:
+              number: 80

--- a/kubernetes/8/ingress/04-clusterrole-binding.yaml
+++ b/kubernetes/8/ingress/04-clusterrole-binding.yaml
@@ -1,6 +1,6 @@
 ---
 #https://github.com/pablokbs/peladonerd/issues/19
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Hola @pablokbs .

Son unas correcciones para usar `networking.k8s.io/v1` en vez de `networking.k8s.io/v1beta1`.

Gracias por compartir.

Saludos