### PR TITLE
Update 04-clusterrole-binding.yaml

### DIFF
--- a/kubernetes/8/ingress/04-clusterrole-binding.yaml
+++ b/kubernetes/8/ingress/04-clusterrole-binding.yaml
@@ -1,6 +1,6 @@
 ---
 #https://github.com/pablokbs/peladonerd/issues/19
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 is deprecated in v1.17+