### PR TITLE
fix error Specified the image version 5.34.0 to avoid the 'Can't use an un…

### DIFF
--- a/kubernetes/23/01-job.yaml
+++ b/kubernetes/23/01-job.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: pi
-        image: perl
+        image: perl:5.34.0
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
When applying `01-job.yaml` the following error is shown on logs. To reproduce:
```bash
$ cat 01-job.yaml | grep 'image: '
        image: perl

$ k apply -f 01-job.yaml 
job.batch/pi created

$ k logs pi-757b5 
Can't use an undefined value as an ARRAY...
```

To solve this, we specified the version of the Docker perl image `5.34.0`

