### PR TITLE
Update metrics-server-deployment.yaml

### DIFF
--- a/kubernetes/5/metrics/metrics-server-deployment.yaml
+++ b/kubernetes/5/metrics/metrics-server-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         image: k8s.gcr.io/metrics-server-amd64:v0.3.1
         imagePullPolicy: Always
         command:
-        - /metrics
+        - /metrics-server
         - --kubelet-insecure-tls
         - --kubelet-preferred-address-types=InternalIP
         volumeMounts:


### PR DESCRIPTION
## CrashLoopBackOff on metrics-server deployment
### Error
The path in `/metrics` in containers.command makes deployment crash. The path cannot be found because it doesn't exists and it causes a CrashLoopBackOff error. This has been tried in a Kind Cluster instead of the minikube clusters that we can see in the videos.

### Solution:
Seems like a typo error at the command path `/metrics`. It should be `/metrics-server`.

