### PR TITLE
agrega priorityClassName para critical pods .spec

### DIFF
--- a/kubernetes/7/06-prometheus-alertmanager-deployment.yaml
+++ b/kubernetes/7/06-prometheus-alertmanager-deployment.yaml
@@ -19,9 +19,8 @@ spec:
       labels:
         k8s-app: alertmanager
         version: v0.14.0
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-node-critical
       containers:
         - name: prometheus-alertmanager
           image: "prom/alertmanager:v0.14.0"


### PR DESCRIPTION
de acuerdo a https://github.com/kubernetes/kubernetes/pull/80342 , "scheduler.alpha.kubernetes.io/critical-pod" fue removido en kubelet 1.16 reemplazado por "priorityClassName:" , como se documenta en: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/